### PR TITLE
Fix test type detection

### DIFF
--- a/src/delfino/commands/test.py
+++ b/src/delfino/commands/test.py
@@ -29,7 +29,7 @@ def _run_tests(app_context: AppContext, name: str, maxfail: int, debug: bool) ->
     print_header(f"️Running {name} tests️", icon="🔎🐛")
     ensure_reports_dir(delfino)
     run(
-        list
+        list(
             filter(
                 None,
                 [
@@ -44,9 +44,9 @@ def _run_tests(app_context: AppContext, name: str, maxfail: int, debug: bool) ->
                     str(maxfail),
                     "-s" if debug else None,
                     delfino.tests_directory / name,
-                ]
+                ],
             )
-        ],
+        ),
         env_update={"COVERAGE_FILE": delfino.reports_directory / f"coverage-{name}.dat"},
         on_error=OnError.ABORT,
     )

--- a/src/delfino/commands/test.py
+++ b/src/delfino/commands/test.py
@@ -29,18 +29,23 @@ def _run_tests(app_context: AppContext, name: str, maxfail: int, debug: bool) ->
     print_header(f"️Running {name} tests️", icon="🔎🐛")
     ensure_reports_dir(delfino)
     run(
-        [
-            "pytest",
-            "--cov",
-            delfino.sources_directory,
-            "--cov-report",
-            f"xml:{delfino.reports_directory / f'coverage-{name}.xml'}",
-            "--cov-branch",
-            "-vv",
-            "--maxfail",
-            str(maxfail),
-            "-s" if debug else "",
-            delfino.tests_directory / name,
+        list
+            filter(
+                None,
+                [
+                    "pytest",
+                    "--cov",
+                    delfino.sources_directory,
+                    "--cov-report",
+                    f"xml:{delfino.reports_directory / f'coverage-{name}.xml'}",
+                    "--cov-branch",
+                    "-vv",
+                    "--maxfail",
+                    str(maxfail),
+                    "-s" if debug else None,
+                    delfino.tests_directory / name,
+                ]
+            )
         ],
         env_update={"COVERAGE_FILE": delfino.reports_directory / f"coverage-{name}.dat"},
         on_error=OnError.ABORT,


### PR DESCRIPTION
Currently if the `--debug` is not provided to `delfino test`, then an empty positional argument is passed to `pytest`.  This is interpreted as "current directory" by pytest, which means that each test type runs the full suite of tests available under the project root directory (assuming the command is run from the root).

This PR updates the pytest invocation to omit the `-s` argument if `--debug` is not supplied.