### PR TITLE
Fix test detection when debug flag is not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes are:
 
 ## [Unreleased]
 
+## [0.12.1] - 2022-01-28
+
+### Fixed
+
+- Fixed a bug where tests are not correctly filtered on their test type if the `--debug` flag is omitted.
+
 ## [0.12.0] - 2022-01-26
 
 ### Added
@@ -159,7 +165,8 @@ Commands can raise `AssertionError` exceptions to tell `delfino` some pre-condit
 
 - Initial copy of source codes.
 
-[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.12.0...HEAD
+[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.12.1...HEAD
+[0.12.1]: https://github.com/radeklat/settings-doc/compare/0.12.0...0.12.1
 [0.12.0]: https://github.com/radeklat/settings-doc/compare/0.11.0...0.12.0
 [0.11.0]: https://github.com/radeklat/settings-doc/compare/0.10.0...0.11.0
 [0.10.0]: https://github.com/radeklat/settings-doc/compare/0.9.0...0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "delfino"
-version = "0.12.0"
+version = "0.12.1"
 description = "A collection of command line helper scripts wrapping tools used during Python development."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 license = "MIT License"

--- a/src/delfino/commands/test.py
+++ b/src/delfino/commands/test.py
@@ -29,19 +29,24 @@ def _run_tests(app_context: AppContext, name: str, maxfail: int, debug: bool) ->
     print_header(f"️Running {name} tests️", icon="🔎🐛")
     ensure_reports_dir(delfino)
     run(
-        [
-            "pytest",
-            "--cov",
-            delfino.sources_directory,
-            "--cov-report",
-            f"xml:{delfino.reports_directory / f'coverage-{name}.xml'}",
-            "--cov-branch",
-            "-vv",
-            "--maxfail",
-            str(maxfail),
-            "-s" if debug else "",
-            delfino.tests_directory / name,
-        ],
+        list(
+            filter(
+                None,
+                [
+                    "pytest",
+                    "--cov",
+                    delfino.sources_directory,
+                    "--cov-report",
+                    f"xml:{delfino.reports_directory / f'coverage-{name}.xml'}",
+                    "--cov-branch",
+                    "-vv",
+                    "--maxfail",
+                    str(maxfail),
+                    "-s" if debug else "",
+                    delfino.tests_directory / name,
+                ],
+            )
+        ),
         env_update={"COVERAGE_FILE": delfino.reports_directory / f"coverage-{name}.dat"},
         on_error=OnError.ABORT,
     )


### PR DESCRIPTION
Currently if the `--debug` is not provided to `delfino test`, then an empty positional argument is passed to `pytest`.  This is interpreted as "current directory" by pytest, which means that each test type runs the full suite of tests available under the project root directory (assuming the command is run from the root).

This PR updates the pytest invocation to omit the `-s` argument if `--debug` is not supplied.