### PR TITLE
Add flag to disable `pre-commit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes are:
 
 ## [Unreleased]
 
+## [0.15.0] - 2022-08-23
+
+### Added
+
+- Configuration now supports a `disable_pre_commit` flag. If set, pre-commit integration is disabled.
+
 ## [0.14.0] - 2022-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Types of changes are:
 
 ## [Unreleased]
 
-## [0.15.0] - 2022-08-23
+## [0.16.0] - 2022-08-23
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ sources_directory = "src"
 tests_directory = "tests"
 test_types = ["unit", "integration"]
 disable_commands = []
+disable_pre_commit = false
 
 [tool.delfino.dockerhub]
 username = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "delfino"
-version = "0.14.0"
+version = "0.15.0"
 description = "A collection of command line helper scripts wrapping tools used during Python development."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 license = "MIT License"

--- a/src/delfino/commands/format.py
+++ b/src/delfino/commands/format.py
@@ -16,7 +16,7 @@ def _check_result(app_context: AppContext, result: CompletedProcess, check: bool
             f" * Run formatter manually with `{run_command_example(run_format, app_context)}` before committing code.",
         ]
         if not app_context.pyproject_toml.tool.delfino.disable_pre_commit:
-            msg_lines.insert(1, f" * Enable pre-commit hook by running `pre-commit install` in the repository.",)
+            msg_lines.insert(1, f" * Enable pre-commit hook by running `pre-commit install` in the repository.")
 
         click.secho(
             "\n".join(msg_lines),

--- a/src/delfino/commands/format.py
+++ b/src/delfino/commands/format.py
@@ -10,10 +10,16 @@ from delfino.validation import assert_pip_package_installed
 
 def _check_result(app_context: AppContext, result: CompletedProcess, check: bool, msg: str):
     if result.returncode == 1 and check:
-        click.secho(
-            f"{msg} before commit. Try following:\n"
-            f" * Enable pre-commit hook by running `pre-commit install` in the repository.\n"
+
+        msg_lines = [
+            f"{msg} before commit. Try following:",
             f" * Run formatter manually with `{run_command_example(run_format, app_context)}` before committing code.",
+        ]
+        if not app_context.pyproject_toml.tool.delfino.disable_pre_commit:
+            msg_lines.insert(1, f" * Enable pre-commit hook by running `pre-commit install` in the repository.",)
+
+        click.secho(
+            "\n".join(msg_lines),
             fg="red",
             err=True,
         )
@@ -29,14 +35,16 @@ def _check_result(app_context: AppContext, result: CompletedProcess, check: bool
 @pass_app_context
 def run_format(app_context: AppContext, check: bool, quiet: bool):
     """Runs black code formatter and isort on source code."""
-    assert_pip_package_installed("pre-commit")
+    delfino = app_context.pyproject_toml.tool.delfino
+
     assert_pip_package_installed("isort")
     assert_pip_package_installed("black")
 
-    # ensure pre-commit is installed
-    run("pre-commit install", stdout=PIPE, on_error=OnError.EXIT)
+    if not delfino.disable_pre_commit:
+        assert_pip_package_installed("pre-commit")
+        # ensure pre-commit is installed
+        run("pre-commit install", stdout=PIPE, on_error=OnError.EXIT)
 
-    delfino = app_context.pyproject_toml.tool.delfino
     dirs = [delfino.sources_directory, delfino.tests_directory]
     flags = []
 

--- a/src/delfino/commands/format.py
+++ b/src/delfino/commands/format.py
@@ -16,7 +16,7 @@ def _check_result(app_context: AppContext, result: CompletedProcess, check: bool
             f" * Run formatter manually with `{run_command_example(run_format, app_context)}` before committing code.",
         ]
         if not app_context.pyproject_toml.tool.delfino.disable_pre_commit:
-            msg_lines.insert(1, f" * Enable pre-commit hook by running `pre-commit install` in the repository.")
+            msg_lines.insert(1, " * Enable pre-commit hook by running `pre-commit install` in the repository.")
 
         click.secho(
             "\n".join(msg_lines),

--- a/src/delfino/models/pyproject_toml.py
+++ b/src/delfino/models/pyproject_toml.py
@@ -15,6 +15,7 @@ class Delfino(BaseModel):
     reports_directory: Path = Path("reports")
     test_types: List[str] = ["unit", "integration"]
     disable_commands: Set[str] = Field(default_factory=set)
+    disable_pre_commit: bool = False
 
     dockerhub: Optional[Dockerhub] = None
 


### PR DESCRIPTION
This PR adds a flag which can be set to disable pre-commit integration. This is useful for projects which haven't set up pre-commit, or who use pre-commit in a different way. One concrete example is a monorepo.

Default behaviour is unchanged.