### PR TITLE
Make `verify-all` respect disabled and overriden commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ Types of changes are:
 
 ## [Unreleased]
 
+## [0.15.0] - 2022-08-23
+
+### Added
+
+- A new configuration field `verify_commands` can be configured to fine-tune which commands are run as part of `verify-all`
+
+### Changed
+
+- The `verify-all` command now respects overridden commands and disabled commands
+
 ## [0.14.0] - 2022-07-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "delfino"
-version = "0.14.0"
+version = "0.15.0"
 description = "A collection of command line helper scripts wrapping tools used during Python development."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 license = "MIT License"

--- a/src/delfino/click_utils/command.py
+++ b/src/delfino/click_utils/command.py
@@ -1,6 +1,6 @@
 from importlib import import_module, resources
 from importlib.resources import Package
-from typing import Dict, List
+from typing import Dict, List, cast
 
 import click
 
@@ -41,3 +41,13 @@ def find_commands(package: Package, *, required: bool, new_name: str = "") -> Di
         click.secho(f"⚠ Plugin module '{package}' is deprecated. Please use '{new_name}' instead.", fg="yellow")
 
     return commands
+
+
+def get_root_command(click_context: click.Context) -> click.MultiCommand:
+    """Find the root command.
+
+    In the context of `delfino`, this is generally the ``main.Commands`` instance.
+    """
+    while click_context.parent:
+        click_context = click_context.parent
+    return cast(click.MultiCommand, click_context.command)

--- a/src/delfino/commands/verify_all.py
+++ b/src/delfino/commands/verify_all.py
@@ -19,7 +19,10 @@ def verify_all(click_context: click.Context, app_context: AppContext):
     delfino = app_context.pyproject_toml.tool.delfino
 
     root = get_root_command(click_context)
-    commands: Dict[str, click.Command] = {command: cast(click.Command, root.get_command(click_context, command)) for command in root.list_commands(click_context)}
+    commands: Dict[str, click.Command] = {
+        command: cast(click.Command, root.get_command(click_context, command))
+        for command in root.list_commands(click_context)
+    }
 
     target_names = [
         command_name for command_name in delfino.verify_commands if command_name not in delfino.disable_commands

--- a/src/delfino/commands/verify_all.py
+++ b/src/delfino/commands/verify_all.py
@@ -24,9 +24,6 @@ def verify_all(click_context: click.Context, app_context: AppContext):
         for command in root.list_commands(click_context)
     }
 
-    target_names = [
-        command_name for command_name in delfino.verify_commands if command_name not in delfino.disable_commands
-    ]
     target_commands = [
         commands[target_name]
         for target_name in delfino.verify_commands

--- a/src/delfino/commands/verify_all.py
+++ b/src/delfino/commands/verify_all.py
@@ -1,16 +1,34 @@
+from typing import Dict, cast
+
 import click
 
-from delfino.click_utils.command import command_names
+from delfino.click_utils.command import get_root_command
 from delfino.commands.format import run_format
 from delfino.commands.lint import lint
 from delfino.commands.test import test_all
 from delfino.commands.typecheck import typecheck
+from delfino.contexts import AppContext, pass_app_context
 
 _COMMANDS = [run_format, lint, typecheck, test_all]
 
 
-@click.command(help=f"Runs all checks.\n\nAlias for the {command_names(_COMMANDS)} commands.")
+@click.command(help="Runs all verification commands. Configured by the ``verify_commands`` setting.")
 @click.pass_context
-def verify_all(click_context: click.Context):
-    for command in _COMMANDS:
+@pass_app_context
+def verify_all(click_context: click.Context, app_context: AppContext):
+    delfino = app_context.pyproject_toml.tool.delfino
+
+    root = get_root_command(click_context)
+    commands: Dict[str, click.Command] = {command: cast(click.Command, root.get_command(click_context, command)) for command in root.list_commands(click_context)}
+
+    target_names = [
+        command_name for command_name in delfino.verify_commands if command_name not in delfino.disable_commands
+    ]
+    target_commands = [
+        commands[target_name]
+        for target_name in delfino.verify_commands
+        if target_name in commands and target_name not in delfino.disable_commands
+    ]
+
+    for command in target_commands:
         click_context.forward(command)

--- a/src/delfino/models/pyproject_toml.py
+++ b/src/delfino/models/pyproject_toml.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from pydantic import BaseModel, Extra, Field
 
@@ -15,6 +15,7 @@ class Delfino(BaseModel):
     reports_directory: Path = Path("reports")
     test_types: List[str] = ["unit", "integration"]
     disable_commands: Set[str] = Field(default_factory=set)
+    verify_commands: Tuple[str, ...] = ("format", "lint", "typecheck", "test-all")
 
     dockerhub: Optional[Dockerhub] = None
 


### PR DESCRIPTION
Related issue: #20 

This PR changes the `verify-all` command, so that overriden and disabled commands are respected by it.

It also adds a configuration option so that users can fine-tune what's included, the ordering, and add entirely new commands.

I think parts of this logic should be applied to other command groups (e.g. `lint`), but I'm not sure it should be part of this PR, as there are differences in how we might want to solve it. For example the `lint` group could just match every command called `lint-*`? Or it could have a separate config option, but that might get messy.