### PR TITLE
[fix] AttributeError: 'Context' object has no attribute 'pyproject_toml'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Types of changes are:
 
 ## [Unreleased]
 
+## [0.16.1] - 2022-09-01
+
+### Fix
+
+- Fix AttributeError when executing verify-all command.
+
 ## [0.16.0] - 2022-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,7 +219,8 @@ Commands can raise `AssertionError` exceptions to tell `delfino` some pre-condit
 
 - Initial copy of source codes.
 
-[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.16.0...HEAD
+[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.16.1...HEAD
+[0.16.1]: https://github.com/radeklat/settings-doc/compare/0.16.0...0.16.1
 [0.16.0]: https://github.com/radeklat/settings-doc/compare/0.15.0...0.16.0
 [0.15.0]: https://github.com/radeklat/settings-doc/compare/0.14.0...0.15.0
 [0.14.0]: https://github.com/radeklat/settings-doc/compare/0.13.1...0.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "delfino"
-version = "0.15.0"
+version = "0.16.1"
 description = "A collection of command line helper scripts wrapping tools used during Python development."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 license = "MIT License"

--- a/src/delfino/commands/verify_all.py
+++ b/src/delfino/commands/verify_all.py
@@ -15,7 +15,7 @@ _COMMANDS = [run_format, lint, typecheck, test_all]
 @click.command(help="Runs all verification commands. Configured by the ``verify_commands`` setting.")
 @click.pass_context
 @pass_app_context
-def verify_all(click_context: click.Context, app_context: AppContext):
+def verify_all(app_context: AppContext, click_context: click.Context):
     delfino = app_context.pyproject_toml.tool.delfino
 
     root = get_root_command(click_context)


### PR DESCRIPTION
recreating https://github.com/radeklat/delfino/pull/23 to run CI.

Invoking `verify-all` commands fails with the following error:

```
% pipenv run delfino verify-all
Loading .env environment variables...
Traceback (most recent call last):
  File "/PATH_TO_REPO/.venv/bin/delfino", line 8, in <module>
    sys.exit(main())
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/delfino/main.py", line 78, in invoke
    return super().invoke(ctx)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/PATH_TO_REPO/.venv/lib/python3.10/site-packages/delfino/commands/verify_all.py", line 19, in verify_all
    delfino = app_context.pyproject_toml.tool.delfino
AttributeError: 'Context' object has no attribute 'pyproject_toml'
```