### PR TITLE
[idea] Add API to configure environment variable for context

### DIFF
--- a/src/delfino/contexts.py
+++ b/src/delfino/contexts.py
@@ -1,19 +1,80 @@
+import subprocess
+from contextlib import contextmanager
+from email import contentmanager
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 from click import make_pass_decorator
 from pydantic import BaseModel
 
 from delfino.constants import PackageManager
+from delfino.execution import OnError, run
 from delfino.models.pyproject_toml import PyprojectToml
+from delfino.utils import ArgsType
 
 
 class AppContext(BaseModel):
     project_root: Path
     pyproject_toml: PyprojectToml
     package_manager: PackageManager
+    _env_update_path: Optional[Dict[str, Any]] = None
+    _env_update: Optional[Dict[str, Dict]] = None
 
     class Config:
         arbitrary_types_allowed = True
+
+    @contextmanager
+    def set_env(self, env_update_path: Optional[Dict[str, Any]] = None, env_update: Optional[Dict[str, Any]] = None):
+        """Set environment variable for the context.
+
+        Args:
+            env_update_path: Same as ``delfino.execution.run``.
+            env_update: Same as ``delfino.execution.run``.
+        """
+        self._env_update_path = env_update_path
+        self._env_update = env_update
+        try:
+            yield self
+        finally:
+            self._env_update_path = None
+            self._env_update = None
+
+    @property
+    def env_update_path(self) -> Dict[str, Any]:
+        return self._env_update_path or {}
+
+    @property
+    def env_update(self) -> Dict[str, Any]:
+        return self._env_update or {}
+
+    def run(
+        self,
+        args: ArgsType,
+        *popenargs,
+        on_error: OnError,
+        env_update_path: Dict[str, Any] = None,
+        env_update: Dict[str, Any] = None,
+        **kwargs,
+    ) -> subprocess.CompletedProcess:
+        """Context enabled version of ``delfino.execution.run``.
+
+        Args:
+            args: Same as ``delfino.execution.run``.
+            *popenargs: Same as ``delfino.execution.run``.
+            on_error: Same as ``delfino.execution.run``.
+                and ``click.Abort``.
+            env_update_path: Same as ``delfino.execution.run`` but ``self.env_update_path``
+                will be merged if not None.
+            env_update: Same as ``delfino.execution.run`` but ``self.env_update`` will be
+                merged if not None.
+            **kwargs: Same as ``delfino.execution.run``.
+        """
+        _env_update_path = self._env_update_path | (env_update_path or {})
+        _env_update = self._env_update | (env_update or {})
+
+        return run(
+            args, *popenargs, on_error=on_error, env_update_path=_env_update_path, env_update=_env_update, **kwargs
+        )
 
 
 pass_app_context = make_pass_decorator(AppContext)


### PR DESCRIPTION
## What 

I'd like to propose adding API to configure environment variable for AppContext; and adding AppContext.run() which respect the configured context.

It means we should always use `AppContext.run()` over `execution.run()` when possible.

Example of new API:
```
update_path = {"PYTHONPATH", delfino.sources_directory}
with app_context.set_env(env_update_path: update_path) as ctx:
    click_context.forward(test_unit)
    ctx.run(...)
```

## Why

With existing design, it is hard to pass environment variable to child commands. We need to write custom code to set/unset environment variable when we want to pass it to child command.

Example:
```
org_pythonpath = os.environ.get("PYTHONPATH", "")
os.environ["PYTHONPATH"] = org_pythonpath + os.pathsep + str(delfino.sources_directory)
click_context.forward(test_unit)
os.environ["PYTHONPATH"] = org_pythonpath
```

