### PR TITLE
Add option/config to the typecheck command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Types of changes are:
 
 ### Added
 
-- Add two options --strict/--path to the typecheck command.
+- Add "strict_directories" config for the typecheck command.
+- Add --path option to the typecheck command.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,15 @@ Types of changes are:
 
 ## [Unreleased]
 
-- Fix typo in the test command header message.
+## [0.18.0] - 2022-09-13
+
+### Added
+
 - Add two options --strict/--path to the typecheck command.
+
+### Fixed
+
+- Fix typo in the test command header message.
 
 ## [0.17.1] - 2022-09-12
 
@@ -234,7 +241,8 @@ Commands can raise `AssertionError` exceptions to tell `delfino` some pre-condit
 
 - Initial copy of source codes.
 
-[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.17.1...HEAD
+[Unreleased]: https://github.com/radeklat/settings-doc/compare/0.18.0...HEAD
+[0.18.0]: https://github.com/radeklat/settings-doc/compare/0.17.1...0.18.0
 [0.17.1]: https://github.com/radeklat/settings-doc/compare/0.17.0...0.17.1
 [0.17.0]: https://github.com/radeklat/settings-doc/compare/0.16.1...0.17.0
 [0.16.1]: https://github.com/radeklat/settings-doc/compare/0.16.0...0.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Types of changes are:
 ### Added
 
 - Add "strict_directories" config for the typecheck command.
-- Add --path option to the typecheck command.
+- Add path argument to the typecheck command.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Types of changes are:
 ## [Unreleased]
 
 - Fix typo in the test command header message.
+- Add two options --strict/--path to the typecheck command.
 
 ## [0.17.1] - 2022-09-12
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "delfino"
-version = "0.17.1"
+version = "0.18.0"
 description = "A collection of command line helper scripts wrapping tools used during Python development."
 authors = ["Radek Lát <radek.lat@gmail.com>"]
 license = "MIT License"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ tests_directory = "tests"
 test_types = ["unit", "integration"]
 disable_commands = ["build-docker"]
 
+#[tool.delfino.typecheck]
+#strict_directories = ['src']
+
 #[tool.delfino.dockerhub]
 #username = "radeklat"
 #build_for_platforms = [

--- a/src/delfino/click_utils/filepaths.py
+++ b/src/delfino/click_utils/filepaths.py
@@ -1,0 +1,7 @@
+import click
+
+filepaths_argument = click.argument(
+    "filepaths",
+    nargs=-1,
+    type=click.Path(exists=True),
+)

--- a/src/delfino/commands/typecheck.py
+++ b/src/delfino/commands/typecheck.py
@@ -43,8 +43,11 @@ def _run_typecheck(paths: List[Path], strict: bool, reports_file: Path, summary_
 
 def is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
     for _path in paths:
-        if path.is_relative_to(_path):
+        try:
+            path.relative_to(_path)
             return True
+        except ValueError:
+            continue
     return False
 
 

--- a/src/delfino/commands/typecheck.py
+++ b/src/delfino/commands/typecheck.py
@@ -42,8 +42,8 @@ def _run_typecheck(paths: List[Path], strict: bool, reports_file: Path, summary_
 
 
 def is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
-    for p in paths:
-        if path.is_relative_to(p):
+    for _path in paths:
+        if path.is_relative_to(_path):
             return True
     return False
 
@@ -66,7 +66,7 @@ def typecheck(app_context: AppContext, summary_only: bool, filepaths: Tuple[str]
 
     target_paths: List[Path] = []
     if filepaths:
-        target_paths = [Path(p) for p in filepaths]
+        target_paths = [Path(path) for path in filepaths]
     else:
         target_paths = [delfino.sources_directory, delfino.tests_directory]
         if app_context.commands_directory.exists():

--- a/src/delfino/commands/typecheck.py
+++ b/src/delfino/commands/typecheck.py
@@ -1,12 +1,12 @@
 """Type checking on source code."""
 
-from ctypes.wintypes import tagMSG
 from itertools import groupby
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import click
 
+from delfino.click_utils.filepaths import filepaths_argument
 from delfino.contexts import AppContext, pass_app_context
 from delfino.execution import OnError, run
 from delfino.terminal_output import print_header
@@ -50,15 +50,9 @@ def is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
 
 @click.command()
 @click.option("--summary-only", is_flag=True, help="Suppress error messages and show only summary error count.")
-@click.option(
-    "--path",
-    "-p",
-    multiple=True,
-    default=[],
-    help="Directory/File paths to type check. Overrides default path when passed.",
-)
+@filepaths_argument
 @pass_app_context
-def typecheck(app_context: AppContext, summary_only: bool, path: List[str]):
+def typecheck(app_context: AppContext, summary_only: bool, filepaths: Tuple[str]):
     """Run type checking on source code.
 
     A non-zero return code from this task indicates invalid types were discovered.
@@ -71,8 +65,8 @@ def typecheck(app_context: AppContext, summary_only: bool, path: List[str]):
     ensure_reports_dir(delfino)
 
     target_paths: List[Path] = []
-    if path:
-        target_paths = [Path(p) for p in path]
+    if filepaths:
+        target_paths = [Path(p) for p in filepaths]
     else:
         target_paths = [delfino.sources_directory, delfino.tests_directory]
         if app_context.commands_directory.exists():

--- a/src/delfino/models/pyproject_toml.py
+++ b/src/delfino/models/pyproject_toml.py
@@ -9,6 +9,10 @@ class Dockerhub(BaseModel):
     username: str
 
 
+class Typecheck(BaseModel):
+    strict_directories: List[Path] = []
+
+
 class Delfino(BaseModel):
     sources_directory: Path = Path("src")
     tests_directory: Path = Path("tests")
@@ -19,6 +23,8 @@ class Delfino(BaseModel):
     disable_pre_commit: bool = False
     dockerhub: Optional[Dockerhub] = None
     plugins: Dict[str, Any] = Field(default_factory=dict, description="Any additional config given by plugins.")
+
+    typecheck: Typecheck = Field(default_factory=Typecheck)
 
     class Config:
         extra = Extra.allow


### PR DESCRIPTION
Would like to add the followings for the typecheck command.

- `filepaths` argument : To overwrite the target directory for mypy
- `strict_directories` config: To specify directory to be checked with `--strict` option.

With this change, we will be able to specify *mode per path*.

For example we can run mypy for `/src` with strict and for `/test` without strict.

See https://github.com/radeklat/delfino/pull/28#issuecomment-1245531786 for the use case.

