### PR TITLE
Add "filepaths" argument to the lint and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Types of changes are:
 
 ## [Unreleased]
 
+- Add "filepaths" argument to the lint and format commands.
+
 ## [0.18.0] - 2022-09-13
 
 ### Added

--- a/src/delfino/commands/lint.py
+++ b/src/delfino/commands/lint.py
@@ -13,7 +13,7 @@ from delfino.click_utils.filepaths import filepaths_argument
 from delfino.contexts import AppContext, pass_app_context
 from delfino.execution import OnError, run
 from delfino.terminal_output import print_header, print_no_issues_found
-from delfino.utils import build_target_paths, is_path_relative_to_paths
+from delfino.utils import _is_path_relative_to_paths, build_target_paths
 from delfino.validation import assert_pip_package_installed, pip_package_installed
 
 
@@ -123,7 +123,7 @@ def lint_pylint(app_context: AppContext, filepaths: Tuple[str]):
     delfino = app_context.pyproject_toml.tool.delfino
 
     def get_pylintrc_folder(path: Path) -> Path:
-        if is_path_relative_to_paths(path, [delfino.tests_directory]):
+        if _is_path_relative_to_paths(path, [delfino.tests_directory]):
             return delfino.tests_directory
         return app_context.project_root
 

--- a/src/delfino/commands/typecheck.py
+++ b/src/delfino/commands/typecheck.py
@@ -10,7 +10,7 @@ from delfino.click_utils.filepaths import filepaths_argument
 from delfino.contexts import AppContext, pass_app_context
 from delfino.execution import OnError, run
 from delfino.terminal_output import print_header
-from delfino.utils import ArgsList, build_target_paths, ensure_reports_dir, is_path_relative_to_paths
+from delfino.utils import ArgsList, _is_path_relative_to_paths, build_target_paths, ensure_reports_dir
 from delfino.validation import assert_pip_package_installed
 
 
@@ -59,7 +59,7 @@ def typecheck(app_context: AppContext, summary_only: bool, filepaths: Tuple[str]
 
     target_paths: List[Path] = build_target_paths(app_context, filepaths)
     strict_paths = delfino.typecheck.strict_directories
-    grouped_paths = groupby(target_paths, lambda current_path: is_path_relative_to_paths(current_path, strict_paths))
+    grouped_paths = groupby(target_paths, lambda current_path: _is_path_relative_to_paths(current_path, strict_paths))
 
     for force_typing, group in grouped_paths:
         report_filepath = (

--- a/src/delfino/utils.py
+++ b/src/delfino/utils.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Tuple, Union
 
 from delfino.constants import PackageManager
+from delfino.contexts import AppContext
 from delfino.models.pyproject_toml import Delfino, PyprojectToml
 
 ArgsList = List[Union[str, bytes, Path]]
@@ -20,3 +21,31 @@ def get_package_manager(project_root: Path, pyproject_toml: PyprojectToml) -> Pa
 def ensure_reports_dir(delfino: Delfino) -> None:
     """Ensures that the reports directory exists."""
     delfino.reports_directory.mkdir(parents=True, exist_ok=True)
+
+
+def is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
+    for _path in paths:
+        try:
+            path.relative_to(_path)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def to_paths(paths: Union[List[str], Tuple[str]]) -> List[Path]:
+    return [Path(path) for path in paths]
+
+
+def build_target_paths(
+    app_context: AppContext, filepaths: Tuple[str] = None, include_tests: bool = True, include_commands: bool = True
+) -> List[Path]:
+    if filepaths:
+        return to_paths(filepaths)
+    delfino = app_context.pyproject_toml.tool.delfino
+    target_paths: List[Path] = [delfino.sources_directory]
+    if include_tests and delfino.tests_directory.exists():
+        target_paths.append(delfino.tests_directory)
+    if include_commands and app_context.commands_directory.exists():
+        target_paths.append(app_context.commands_directory)
+    return target_paths

--- a/src/delfino/utils.py
+++ b/src/delfino/utils.py
@@ -23,25 +23,11 @@ def ensure_reports_dir(delfino: Delfino) -> None:
     delfino.reports_directory.mkdir(parents=True, exist_ok=True)
 
 
-def is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
-    for _path in paths:
-        try:
-            path.relative_to(_path)
-            return True
-        except ValueError:
-            continue
-    return False
-
-
-def to_paths(paths: Union[List[str], Tuple[str]]) -> List[Path]:
-    return [Path(path) for path in paths]
-
-
 def build_target_paths(
     app_context: AppContext, filepaths: Tuple[str] = None, include_tests: bool = True, include_commands: bool = True
 ) -> List[Path]:
     if filepaths:
-        return to_paths(filepaths)
+        return [Path(path) for path in filepaths]
     delfino = app_context.pyproject_toml.tool.delfino
     target_paths: List[Path] = [delfino.sources_directory]
     if include_tests and delfino.tests_directory.exists():
@@ -49,3 +35,13 @@ def build_target_paths(
     if include_commands and app_context.commands_directory.exists():
         target_paths.append(app_context.commands_directory)
     return target_paths
+
+
+def _is_path_relative_to_paths(path: Path, paths: List[Path]) -> bool:
+    for _path in paths:
+        try:
+            path.relative_to(_path)
+            return True
+        except ValueError:
+            continue
+    return False


### PR DESCRIPTION
Add "filepaths" argument, which was introduced by https://github.com/radeklat/delfino/pull/28 for the typecheck command, to the lint and format commands.