### PR TITLE
Fixing subprocess.poll hang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "shellingham>=1.4",
     "types-toml",
     "delfino-core[verify,dependencies-update]>=9.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -1,0 +1,63 @@
+import subprocess as sp
+from pathlib import Path
+
+import pytest
+
+from src.delfino.execution import OnError, run
+
+# Test constants
+MAX_EXECUTION_TIME_SECONDS = 30
+
+
+def _big_dual_stream_cmd(total_bytes: int = 64 * 1024 * 1024, chunk: int = 64 * 1024):
+    """Creates a shell command that outputs large amounts of data to both stdout and stderr.
+
+    This tests for deadlock conditions when parent processes don't properly handle
+    concurrent reading from both output streams.
+    """
+    shell_script = f"""
+# Configuration
+TOTAL_BYTES={total_bytes}
+CHUNK_SIZE={chunk}
+
+# Create buffers - strings of A's and B's for stdout/stderr
+STDOUT_CHUNK=$(printf 'A%.0s' $(seq 1 $CHUNK_SIZE))
+STDERR_CHUNK=$(printf 'B%.0s' $(seq 1 $CHUNK_SIZE))
+
+# Write data alternately to both streams
+written=0
+while [ $written -lt $TOTAL_BYTES ]; do
+    # Write to stdout (file descriptor 1)
+    printf '%s' "$STDOUT_CHUNK" >&1
+
+    # Write to stderr (file descriptor 2)
+    printf '%s' "$STDERR_CHUNK" >&2
+
+    # Update bytes written counter
+    written=$((written + 2 * CHUNK_SIZE))
+done
+
+exit 0
+"""
+    return ["/bin/sh", "-c", shell_script.strip()]
+
+
+class TestExecution:
+    @pytest.mark.timeout(10)
+    @staticmethod
+    def should_run_without_deadlock_on_large_both_streams(tmp_path: Path):
+        cmd = _big_dual_stream_cmd(total_bytes=64 * 1024 * 1024, chunk=64 * 1024)
+
+        cp = run(
+            cmd,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+            on_error=OnError.PASS,
+            running_hook=lambda: None,
+            text=False,
+        )
+
+        # 正常終了し、双方の出力が十分にあることを確認
+        assert cp.returncode == 0
+        assert isinstance(cp.stdout, (bytes, bytearray)) and len(cp.stdout) > 0
+        assert isinstance(cp.stderr, (bytes, bytearray)) and len(cp.stderr) > 0

--- a/tests/integration/test_execution.py
+++ b/tests/integration/test_execution.py
@@ -57,7 +57,6 @@ class TestExecution:
             text=False,
         )
 
-        # 正常終了し、双方の出力が十分にあることを確認
         assert cp.returncode == 0
         assert isinstance(cp.stdout, (bytes, bytearray)) and len(cp.stdout) > 0
         assert isinstance(cp.stderr, (bytes, bytearray)) and len(cp.stderr) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0"
 
 [[package]]
@@ -150,6 +150,7 @@ completion = [
 [package.dev-dependencies]
 dev = [
     { name = "delfino-core", extra = ["dependencies-update", "verify"] },
+    { name = "pytest-timeout" },
     { name = "shellingham" },
     { name = "types-toml" },
 ]
@@ -167,6 +168,7 @@ provides-extras = ["completion"]
 [package.metadata.requires-dev]
 dev = [
     { name = "delfino-core", extras = ["verify", "dependencies-update"], specifier = ">=9.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "shellingham", specifier = ">=1.4" },
     { name = "types-toml" },
 ]
@@ -537,6 +539,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432, upload-time = "2025-06-12T10:47:47.684Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644, upload-time = "2025-06-12T10:47:45.932Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hi!

I found that command execution hangs when the command output is large.
For example, when mypy produces a large number of errors and the PIPE buffer becomes full, the command execution hangs (see [docs](https://docs.python.org/ja/3/library/subprocess.html#subprocess.Popen.wait)). I added a test to reproduce this issue.

This fix replaces the use of poll with communicate to prevent the hang.